### PR TITLE
Adding tests for Phi-3-mini-4k-instruct

### DIFF
--- a/model_serving_tests/model_config/model_inference/phi-3-mini-4k-instruct/phi-3-mini-4k-instruct.yaml
+++ b/model_serving_tests/model_config/model_inference/phi-3-mini-4k-instruct/phi-3-mini-4k-instruct.yaml
@@ -1,0 +1,61 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    # Overwritten by templates
+    serving.kserve.io/enable-prometheus-scraping: "true"
+    serving.kserve.io/deploymentMode: {{ deployment_mode | default("RawDeployment") }}
+  labels:
+    opendatahub.io/dashboard: "true"
+  name: {{ model_name | default("phi-3-mini-4k-instruct") }}
+spec:
+  predictor:
+    minReplicas: {{ min_replica | default(1) }}
+    serviceAccountName: modelmesh-serving-sa
+    model:
+      modelFormat:
+        name: {{ model_format | default("pytorch") }}
+      runtime: {{ runtime_name | default("vllm-runtime") }}
+      storageUri: {{ storage_uri | default("s3://ods-ci-wisdom/phi-3-mini-4k-instruct/") }}
+      args:
+        - --dtype=bfloat16
+        - --model=/mnt/models
+        - --uvicorn-log-level=debug
+        - --served-model-name={{ model_name | default("phi-3-mini-4k-instruct") }}
+        {% for arg in new_args %}
+        - {{ arg }}
+        {% endfor %}
+      env:
+        - name: HF_HUB_CACHE
+          value: /tmp
+        {% for var in env_vars %}
+        - name: {{ var.name }}
+          value: {{ var.value }}
+        {% endfor %}
+      resources:
+        requests:
+          cpu: "8"
+          memory: "14Gi"
+          
+        limits:
+          memory: "15Gi"
+      volumeMounts:
+        {% if gpu_count | default(0) | int >= 2 %}
+        - name: shared-memory
+          mountPath: /dev/shm
+        - name: tmp
+          mountPath: /tmp
+        - name: home
+          mountPath: /home/vllm
+        {% endif %}
+    volumes:
+      {% if gpu_count | default(0) | int >= 2 %}
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+          sizeLimit: 16Gi
+      - name: tmp
+        emptyDir: {}
+      - name: home
+        emptyDir: {}
+      {% endif %}

--- a/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].1.json
+++ b/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].1.json
@@ -1,0 +1,1 @@
+"max_sequence_length: 4096\nmax_new_tokens: 1024\n"

--- a/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].2.json
+++ b/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].2.json
@@ -1,0 +1,6 @@
+{
+  "input_tokens": 0,
+  "output_text": "\n\n\n### Answer:\n1. Labrador Retriever: Known for their friendly and outgoing nature, Labradors are excellent family pets. They are intelligent, eager to please, and have a strong desire to work and play.\n\n2. German Shepherd: German Shepherds are highly intelligent, loyal, and versatile dogs. They are often used as working dogs in various fields such as police, military, and search and rescue.\n\n3. Golden Retriever: Golden Retrievers are friendly, gentle, and good with children. They are also known for their intelligence and love for water, making them great family pets and excellent hunting companions.\n\n4. Bulldog: Bulldogs are known for their distinctive wrinkled face and muscular build. They are generally calm, friendly, and good with children. However, they require regular exercise and grooming due to their short coat.\n\n5. Beagle: Beagles are small to medium-sized dogs known for their friendly and curious nature. They are excellent scent hounds and make great family pets. They require regular exercise and have a high prey drive, so they should be kept on a leash or in a securely fenced area.\n\n\n",
+  "output_tokens": 273,
+  "stop_reason": 2
+}

--- a/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].3.json
+++ b/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].3.json
@@ -1,0 +1,8 @@
+{
+  "finish_reason": "length",
+  "index": 0,
+  "logprobs": null,
+  "prompt_logprobs": null,
+  "stop_reason": null,
+  "text": " Format your answer as a bullet list, including the breed name followed by its"
+}

--- a/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].4.json
+++ b/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].4.json
@@ -1,0 +1,12 @@
+{
+  "finish_reason": "stop",
+  "index": 0,
+  "logprobs": null,
+  "message": {
+    "content": " Certainly! Bananas and dragonfruits can be combined in various delicious ways. Here are some ideas for incorporating these fruits into your meals and snacks:\n\n1. Smoothie: Blend together bananas, dragonfruit, a handful of spinach or kale, a tablespoon of chia seeds, and a splash of almond milk or coconut water for a refreshing and nutritious smoothie.\n\n2. Salad: Toss together sliced bananas, dragonfruit, mixed greens, avocado, and a light vinaigrette dressing for a colorful and healthy salad.\n\n3. Parfait: Layer sliced bananas, dragonfruit, and Greek yogurt in a glass or jar, and top with a sprinkle of granola or nuts for a satisfying and nutritious parfait.\n\n4. Salsa: Dice up bananas and dragonfruit, and mix with chopped tomatoes, red onion, cilantro, lime juice, and a pinch of salt for a sweet and tangy salsa that pairs well with grilled chicken or fish.\n\n5. Oatmeal: Top your morning oatmeal with sliced bananas and dragonfruit for a sweet and nutritious breakfast.\n\n6. Pancakes: Add mashed bananas and diced dragonfruit to your pancake batter for a unique and flavorful twist on a classic breakfast dish.\n\n7. Dessert: Bake a banana and dragonfruit cake or muffins, or make a fruit salad with sliced bananas and dragonfruit, and top with a drizzle of honey or a sprinkle of cinnamon.\n\n8. Snack: Slice bananas and dragonfruit and serve with a side of hummus or nut butter for a healthy and satisfying snack.\n\n9. Soup: Blend together cooked bananas, dragonfruit, vegetable broth, and your choice of seasonings for a creamy and flavorful soup.\n\n10. Skewers: Thread slices of bananas and dragonfruit onto skewers and grill or roast for a fun and colorful appetizer or side dish.\n\nRemember to experiment with different combinations and seasonings to find the flavors that work best for you. Enjoy!",
+    "reasoning_content": null,
+    "role": "assistant",
+    "tool_calls": []
+  },
+  "stop_reason": 32007
+}

--- a/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].json
+++ b/model_serving_tests/tests/model_deployment/__snapshots__/test_phi_3_mini_4k_instruct/test_phi_4_instruct_simple[phi-3-mini-4k-instruct-RawDeployment].json
@@ -1,0 +1,6 @@
+{
+  "input_tokens": 12,
+  "output_text": "\n\n\n### Answer:\n1. Labrador Retriever: Known for their friendly and outgoing nature, Labradors are excellent family pets. They are intelligent, eager to please, and have a strong desire to work and play.\n\n2. German Shepherd: German Shepherds are highly intelligent, loyal, and versatile dogs. They are often used as working dogs in various fields such as police, military, and search and rescue.\n\n3. Golden Retriever: Golden Retrievers are friendly, gentle, and good with children. They are also known for their intelligence and love for water, making them great family pets and excellent hunting companions.\n\n4. Bulldog: Bulldogs are known for their distinctive wrinkled face and muscular build. They are generally calm, friendly, and good with children. However, they require regular exercise and grooming due to their short coat.\n\n5. Beagle: Beagles are small to medium-sized dogs known for their friendly and curious nature. They are excellent scent hounds and make great family pets. They require regular exercise and have a high prey drive, so they should be kept on a leash or in a securely fenced area.\n\n\n",
+  "output_tokens": 273,
+  "stop_reason": 2
+}

--- a/model_serving_tests/tests/model_deployment/test_phi_3_mini_4k_instruct.py
+++ b/model_serving_tests/tests/model_deployment/test_phi_3_mini_4k_instruct.py
@@ -1,0 +1,205 @@
+from typing import Any, Callable
+import pytest
+from kubernetes.dynamic.client import DynamicClient
+from ocp_resources.resource import Resource
+from model_serving_tests.endpoint_utility.openai_utility import OpenAIClient
+from model_serving_tests.endpoint_utility.grpc_utility import TGISGRPCPlugin
+from model_serving_tests.tests.utils import create_runtime_manifest_from_template, create_isvc_manifest_from_template, \
+    get_predictor_pod, create_s3_secret_manifest
+import logging
+import time
+
+LOGGER = logging.getLogger(__name__)
+
+MODEL_NAMES =  ['phi-3-mini-4k-instruct']
+DEPLOYMENT_TYPES = ["RawDeployment"]
+
+COMPLETION_QUERY = {
+    "text": "List the top five breeds of dogs and their characteristics.",
+}
+
+CHAT_QUERY = [
+    {
+        "role": "user",
+        "content": "Can you provide ways to eat combinations of bananas and dragonfruits?"
+    }
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.phi4k
+@pytest.mark.parametrize("deployment_type", DEPLOYMENT_TYPES)
+@pytest.mark.parametrize("model_name", MODEL_NAMES)
+def test_phi_4_instruct_simple(client: DynamicClient,
+                                    run_static_command: Callable[[str], None],
+                                    response_snapshot: Any,
+                                    create_namespace: Callable[[str], Resource],
+                                    create_secret_from_file: Callable[[str], Resource],
+                                    create_service_account: Callable[[str], Resource],
+                                    create_serving_runtime_from_file: Callable[[str, str], Resource],
+                                    create_isvc_from_file: Callable[[str, str], Resource],
+                                    model_name: str,
+                                    deployment_type: str,
+                                    runtime: str,
+                                    runtime_image: str,
+                                    accelerator_type: str,
+                                    runtime_name: str) -> None:
+    """
+    Test function for validating the deployment and serving of a model in a Kubernetes environment.
+
+    This function performs the following steps:
+    1. Creates necessary Kubernetes resources (namespace, secret, service account, serving runtime, and inference service).
+    2. Waits for the predictor pod to be in a "Running" and "Ready" state.
+    3. Depending on the deployment type, performs port-forwarding or uses the provided URL to access the model.
+    4. Sends requests to the model and compares responses with predefined snapshots.
+
+    Args:
+        client (DynamicClient): The client used to interact with the Kubernetes cluster.
+        run_static_command (Callable[[str], None]): A function to execute static commands in the environment.
+        response_snapshot (Any): A snapshot object for response comparison.
+        create_namespace (Callable[[str], Resource]): A function to create a new Kubernetes namespace.
+        create_secret_from_file (Callable[[str], Secret]): A function to create a Kubernetes secret from a file.
+        create_service_account (Callable[[str], ServiceAccount]): A function to create a Kubernetes service account.
+        create_serving_runtime_from_file (Callable[[str, str], ServingRuntime]): A function to create a serving runtime from a file.
+        create_isvc_from_file (Callable[[str, str], InferenceService]): A function to create an inference service from a file.
+        model_name (str): The name of the model to be deployed.
+        deployment_type (str): The type of deployment (e.g., "rawdeployment" or "serverless").
+        runtime (str, optional): The runtime environment. Defaults to "vLLM".
+        runtime_name (str, optional): The name of the serving runtime. Defaults to "serving_runtime".
+    """
+    namespace_name = model_name.lower()
+    create_runtime_manifest_from_template(deployment_type, runtime_image, runtime_name)
+    create_isvc_manifest_from_template(deployment_type, model_name, accelerator_type=accelerator_type, gpu_count=1)
+    create_s3_secret_manifest()
+    namespace = create_namespace(namespace_name)
+    secret = create_secret_from_file(namespace=namespace.name)
+    service_account = create_service_account(namespace=namespace.name)
+    serving_runtime = create_serving_runtime_from_file(namespace=namespace.name, path=runtime)
+    inference_service = create_isvc_from_file(namespace=namespace.name, model_name=model_name)
+    time.sleep(10)
+    predictor_pod = get_predictor_pod(client, namespace=namespace.name, is_name=inference_service.name)
+    predictor_pod.wait_for_status("Running", timeout=600)
+    predictor_pod.wait_for_condition("Ready", "True", timeout=600)
+    time.sleep(10)
+    LOGGER.info(f"Model statuts: {inference_service.instance.status.modelStatus.states.activeModelState}")
+    if inference_service.instance.status.modelStatus.states.activeModelState != "Loaded":
+        pytest.fail("Model is not in Loaded state")
+    if deployment_type.lower() == "rawdeployment":
+        #grpc
+        cmd = f"oc -n {namespace_name} port-forward pod/{predictor_pod.name} 8033:8033"
+        run_static_command(cmd)
+        url = "localhost:8033"
+        tgis_client = TGISGRPCPlugin(host=url, model_name=model_name, streaming=True)
+        all_token = tgis_client.make_grpc_request(COMPLETION_QUERY)
+        LOGGER.info(all_token)
+        model_info = tgis_client.get_model_info()
+        LOGGER.info(model_info)
+        stream = tgis_client.make_grpc_request_stream(COMPLETION_QUERY)
+        LOGGER.info(stream)
+        assert all_token == response_snapshot
+        assert model_info == response_snapshot
+        assert stream == response_snapshot
+        # Forward port to access the service locally
+        cmd = f"oc -n {namespace_name} port-forward pod/{predictor_pod.name} 8080:8080"
+        run_static_command(cmd)
+        url = "http://localhost:8080"
+
+        openai_client = OpenAIClient(host=url, model_name=model_name)
+        completion_response = openai_client.request_http(endpoint="/v1/completions", query=COMPLETION_QUERY)
+        chat_response = openai_client.request_http(endpoint="/v1/chat/completions", query=CHAT_QUERY)
+
+        assert completion_response == response_snapshot
+        assert chat_response == response_snapshot
+
+    elif deployment_type.lower() == "serverless":
+        url = inference_service.instance.status.url
+        LOGGER.info(url)
+
+        openai_client = OpenAIClient(host=url + ":443", model_name=model_name)
+        completion_response = openai_client.request_http(endpoint="/v1/completions", query=COMPLETION_QUERY)
+        chat_response = openai_client.request_http(endpoint="/v1/chat/completions", query=CHAT_QUERY)
+
+        assert completion_response == response_snapshot
+        assert chat_response == response_snapshot
+    else:
+        LOGGER.warning("Deployment type is not provided correctly.")
+
+@pytest.mark.smoke
+@pytest.mark.phi4k
+@pytest.mark.xfail(reason="This test is expected to fail with the error input tokens (12) plus prefix length (0) must "
+                          "be < 10.for grpc endpoint. For openai endpoint it will throw request error with http status "
+                          "400")
+@pytest.mark.parametrize("deployment_type", DEPLOYMENT_TYPES)
+@pytest.mark.parametrize("model_name", MODEL_NAMES)
+def test_phi_instruct_4k_seq_len(client: DynamicClient,
+                                        run_static_command: Callable[[str], None],
+                                        create_namespace: Callable[[str], Resource],
+                                        create_secret_from_file: Callable[[str], Resource],
+                                        create_service_account: Callable[[str], Resource],
+                                        create_serving_runtime_from_file: Callable[[str, str], Resource],
+                                        create_isvc_from_file: Callable[[str, str], Resource],
+                                        model_name: str,
+                                        deployment_type: str,
+                                        runtime: str,
+                                        runtime_image: str,
+                                        accelerator_type: str,
+                                        runtime_name: str) -> None:
+    """
+    Test function for validating the deployment and serving of a model with small model length
+
+    Args:
+        client (DynamicClient): The client used to interact with the Kubernetes cluster.
+        run_static_command (Callable[[str], None]): A function to execute static commands in the environment.
+        create_namespace (Callable[[str], Resource]): A function to create a new Kubernetes namespace.
+        create_secret_from_file (Callable[[str], Secret]): A function to create a Kubernetes secret from a file.
+        create_service_account (Callable[[str], ServiceAccount]): A function to create a Kubernetes service account.
+        create_serving_runtime_from_file (Callable[[str, str], ServingRuntime]): A function to create a serving runtime from a file.
+        create_isvc_from_file (Callable[[str, str], InferenceService]): A function to create an inference service from a file.
+        model_name (str): The name of the model to be deployed.
+        deployment_type (str): The type of deployment (e.g., "rawdeployment" or "serverless").
+        runtime (str, optional): The runtime environment. Defaults to "vLLM".
+        runtime_name (str, optional): The name of the serving runtime. Defaults to "serving_runtime".
+    """
+    namespace_name = model_name.lower()
+
+    create_runtime_manifest_from_template(deployment_type, runtime_image, runtime_name)
+    create_isvc_manifest_from_template(deployment_type, model_name, accelerator_type=accelerator_type,
+                                       new_args=["--max-model-len=10"])
+    create_s3_secret_manifest()
+    namespace = create_namespace(namespace_name)
+    secret = create_secret_from_file(namespace=namespace.name)
+    service_account = create_service_account(namespace=namespace.name)
+    serving_runtime = create_serving_runtime_from_file(namespace=namespace.name, path=runtime)
+    inference_service = create_isvc_from_file(namespace=namespace.name, model_name=model_name)
+    time.sleep(10)
+    predictor_pod = get_predictor_pod(client, namespace=namespace.name, is_name=inference_service.name)
+    predictor_pod.wait_for_status("Running", timeout=600)
+    predictor_pod.wait_for_condition("Ready", "True", timeout=600)
+    time.sleep(10)
+    if inference_service.instance.status.modelStatus.states.activeModelState != "Loaded":
+        pytest.fail("Model is not in Loaded state")
+
+    if deployment_type.lower() == "rawdeployment":
+        cmd = f"oc -n {namespace_name} port-forward pod/{predictor_pod.name} 8033:8033"
+        run_static_command(cmd)
+        url = "localhost:8033"
+        tgis_client = TGISGRPCPlugin(host=url, model_name=model_name, streaming=True)
+        model_info = tgis_client.get_model_info()
+        LOGGER.info(model_info)
+        try:
+            all_token = tgis_client.make_grpc_request(COMPLETION_QUERY)
+            LOGGER.info(all_token)
+            assert response is not None
+        except grpc.RpcError as e:
+            error_message = e.details()
+            if "input tokens (12) plus prefix length (0) must be < 10" in error_message:
+                pytest.xfail(f"Expected failure occurred: {error_message}")
+            else:
+                pytest.fail(f"Unexpected gRPC error: {error_message}")
+    elif deployment_type.lower() == "serverless":
+        url = inference_service.instance.status.url
+        LOGGER.info(url)
+        openai_client = OpenAIClient(host=url + ":443", model_name=model_name)
+        chat_response = openai_client.request_http(endpoint="/v1/chat/completions", query=CHAT_QUERY)
+    else:
+        LOGGER.warning("Deployment type is not provided correctly.")

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,4 @@ markers =
     smoke: Basic model deployment tests
     multigpu: Test case which needs two or more GPUs
     granite4k: Test for new granite RHEL AI model
+    phi4k: Test for Phi model


### PR DESCRIPTION
Hi Tarun, 
This PR adds tests for two scenarios: deployment and serving of a model in a Kubernetes/OCP environment, and validation with a small model length.

logs: [py-phi4k-output.txt](https://github.com/user-attachments/files/19363238/py-phi4k-output.txt)
For testing purpose, I used different bucket.